### PR TITLE
Applied unicode fix to submit_ham/submit_spam

### DIFF
--- a/akismet.py
+++ b/akismet.py
@@ -63,7 +63,7 @@ if hasattr(socket, 'setdefaulttimeout'):
     # Set the default timeout on sockets to 5 seconds
     socket.setdefaulttimeout(5)
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 __all__ = (
     '__version__',


### PR DESCRIPTION
The urlencode(data, doseq=True) fix had only been applied to comment_check. This commit makes the same changes to submit_ham and submit_spam.
